### PR TITLE
Fix breaking changes of clap v3's beta5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
 dependencies = [
  "atty",
  "bitflags",
@@ -498,15 +498,14 @@ dependencies = [
  "termcolor",
  "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+ "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1124,9 +1123,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "2.4.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "output_vt100"
@@ -1276,9 +1278,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -1646,9 +1648,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1676,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "terminal_size",
  "unicode-width",
@@ -1900,6 +1902,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,12 +1963,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codegen-units = 1
 panic = 'abort'
 
 [dependencies]
-clap = { version = "3.0.0-beta.2", features = ["wrap_help"] }
+clap = { version = "3.0.0-beta.5", features = ["color", "wrap_help"] }
 actix-web = { version= "3", features = ["rustls"] }
 simplelog = "0.11"
 log = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use actix_web::http::{HeaderMap, HeaderName, HeaderValue};
-use clap::Clap;
+use clap::Parser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use url::Url;
@@ -25,14 +25,8 @@ fn parse_header(header: &str) -> Result<HeaderMap, String> {
     Ok(map)
 }
 
-#[derive(Clap, Debug, Clone)]
-#[clap(
-    name = "proxyboi",
-    version,
-    author,
-    about,
-    setting = clap::AppSettings::ColoredHelp,
-)]
+#[derive(Parser, Debug, Clone)]
+#[clap(name = "proxyboi", version, author, about)]
 pub struct ProxyboiConfig {
     /// Socket to listen on
     #[clap(short, long, default_value = "0.0.0.0:8080")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use actix_web::client::{ClientBuilder, Connector};
 use actix_web::{web, App, HttpServer};
-use clap::Clap;
+use clap::Parser;
 use log::trace;
 use rustls::{
     Certificate, ClientConfig, NoClientAuth, RootCertStore, ServerCertVerified, ServerCertVerifier,


### PR DESCRIPTION
Recently a lot of tools broke for me when I had to reinstall them via `cargo install`. Interestingly that install command [doesn't respect the lock file per default](https://github.com/rust-lang/cargo/issues/7169).

Nevertheless we want our dependencies up to date, esp when on beta branches and breaking changes. I hope clap doesn't break more before the final release.

Here the changes were fairly simple.

Reference:
https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#v300-beta5-2021-10-18